### PR TITLE
feat(http): add HEAD, OPTIONS, and custom HTTP method support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -174,16 +174,47 @@ impl HttpMethod {
         Self::ALL[index % Self::ALL.len()]
     }
 
-    pub fn from_str(value: &str) -> Self {
-        match value.to_uppercase().as_str() {
-            "POST" => HttpMethod::Post,
-            "PUT" => HttpMethod::Put,
-            "PATCH" => HttpMethod::Patch,
-            "DELETE" => HttpMethod::Delete,
-            "HEAD" => HttpMethod::Head,
-            "OPTIONS" => HttpMethod::Options,
-            _ => HttpMethod::Get,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Method {
+    Standard(HttpMethod),
+    Custom(String),
+}
+
+impl Default for Method {
+    fn default() -> Self {
+        Method::Standard(HttpMethod::Get)
+    }
+}
+
+impl Method {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Method::Standard(m) => m.as_str(),
+            Method::Custom(s) => s.as_str(),
         }
+    }
+
+    pub fn from_str(value: &str) -> Self {
+        let upper = value.to_uppercase();
+        match upper.as_str() {
+            "GET" => Method::Standard(HttpMethod::Get),
+            "POST" => Method::Standard(HttpMethod::Post),
+            "PUT" => Method::Standard(HttpMethod::Put),
+            "PATCH" => Method::Standard(HttpMethod::Patch),
+            "DELETE" => Method::Standard(HttpMethod::Delete),
+            "HEAD" => Method::Standard(HttpMethod::Head),
+            "OPTIONS" => Method::Standard(HttpMethod::Options),
+            _ => Method::Custom(upper),
+        }
+    }
+
+}
+
+impl From<HttpMethod> for Method {
+    fn from(m: HttpMethod) -> Self {
+        Method::Standard(m)
     }
 }
 
@@ -284,7 +315,7 @@ pub struct SidebarLine {
     pub marker: String,
     pub label: String,
     pub kind: NodeKind,
-    pub method: Option<HttpMethod>,
+    pub method: Option<Method>,
 }
 
 struct SidebarCache {
@@ -317,7 +348,7 @@ impl SidebarCache {
 }
 
 pub struct RequestState {
-    pub method: HttpMethod,
+    pub method: Method,
     pub url_editor: TextArea<'static>,
     pub headers_editor: TextArea<'static>,
     pub body_editor: TextArea<'static>,
@@ -342,14 +373,14 @@ impl RequestState {
         configure_editor(&mut body_editor, "Request body...");
 
         Self {
-            method: HttpMethod::default(),
+            method: Method::default(),
             url_editor,
             headers_editor,
             body_editor,
         }
     }
 
-    pub fn set_contents(&mut self, method: HttpMethod, url: String, headers: String, body: String) {
+    pub fn set_contents(&mut self, method: Method, url: String, headers: String, body: String) {
         self.method = method;
         let url_lines = if url.is_empty() { vec![String::new()] } else { vec![url] };
         let header_lines = if headers.is_empty() {
@@ -477,6 +508,8 @@ pub struct App {
     pub show_help: bool,
     pub show_method_popup: bool,
     pub method_popup_index: usize,
+    pub method_popup_custom_mode: bool,
+    pub method_custom_input: String,
     pub sidebar_visible: bool,
     pub sidebar_width: u16,
     pub collection: CollectionStore,
@@ -643,6 +676,8 @@ impl App {
             show_help: false,
             show_method_popup: false,
             method_popup_index: 0,
+            method_popup_custom_mode: false,
+            method_custom_input: String::new(),
             sidebar_visible,
             sidebar_width,
             collection,
@@ -918,7 +953,7 @@ impl App {
                 let method = if node.kind == NodeKind::Request {
                     node.request_method
                         .as_deref()
-                        .map(HttpMethod::from_str)
+                        .map(Method::from_str)
                 } else {
                     None
                 };
@@ -955,7 +990,7 @@ impl App {
             let method = if node.kind == NodeKind::Request {
                 node.request_method
                     .as_deref()
-                    .map(HttpMethod::from_str)
+                    .map(Method::from_str)
             } else {
                 None
             };
@@ -1089,7 +1124,7 @@ impl App {
         self.save_current_request_if_dirty();
         if let Some(item) = self.collection.get_item(request_id) {
             if let Some(request) = &item.request {
-                let method = HttpMethod::from_str(&request.method);
+                let method = Method::from_str(&request.method);
                 let url = extract_url(&request.url);
                 let headers = headers_to_text(&request.header);
                 let body = request
@@ -2083,26 +2118,69 @@ impl App {
 
         // Handle method popup navigation when open
         if self.show_method_popup {
-            match key.code {
-                KeyCode::Down | KeyCode::Char('j') => {
-                    self.method_popup_index =
-                        (self.method_popup_index + 1) % HttpMethod::ALL.len();
+            let popup_item_count = HttpMethod::ALL.len() + 1; // 7 standard + "Custom..."
+
+            if self.method_popup_custom_mode {
+                // Text input mode for custom method
+                match key.code {
+                    KeyCode::Enter => {
+                        let input = self.method_custom_input.trim().to_string();
+                        if !input.is_empty()
+                            && input.is_ascii()
+                            && !input.contains(char::is_whitespace)
+                        {
+                            self.request.method = Method::Custom(input.to_uppercase());
+                            self.show_method_popup = false;
+                            self.method_popup_custom_mode = false;
+                            self.request_dirty = true;
+                        }
+                    }
+                    KeyCode::Esc => {
+                        self.method_custom_input.clear();
+                        self.method_popup_custom_mode = false;
+                        self.show_method_popup = false;
+                    }
+                    KeyCode::Backspace => {
+                        self.method_custom_input.pop();
+                    }
+                    KeyCode::Char(c) if c.is_ascii() && !c.is_whitespace() => {
+                        if self.method_custom_input.len() < 20 {
+                            self.method_custom_input.push(c.to_ascii_uppercase());
+                        }
+                    }
+                    _ => {}
                 }
-                KeyCode::Up | KeyCode::Char('k') => {
-                    self.method_popup_index = if self.method_popup_index == 0 {
-                        HttpMethod::ALL.len() - 1
-                    } else {
-                        self.method_popup_index - 1
-                    };
+            } else {
+                // Standard popup navigation mode
+                match key.code {
+                    KeyCode::Down | KeyCode::Char('j') => {
+                        self.method_popup_index =
+                            (self.method_popup_index + 1) % popup_item_count;
+                    }
+                    KeyCode::Up | KeyCode::Char('k') => {
+                        self.method_popup_index = if self.method_popup_index == 0 {
+                            popup_item_count - 1
+                        } else {
+                            self.method_popup_index - 1
+                        };
+                    }
+                    KeyCode::Enter => {
+                        if self.method_popup_index < HttpMethod::ALL.len() {
+                            self.request.method = Method::Standard(
+                                HttpMethod::from_index(self.method_popup_index),
+                            );
+                            self.show_method_popup = false;
+                            self.request_dirty = true;
+                        } else {
+                            // "Custom..." selected — enter text input mode
+                            self.method_popup_custom_mode = true;
+                        }
+                    }
+                    KeyCode::Esc => {
+                        self.show_method_popup = false;
+                    }
+                    _ => {}
                 }
-                KeyCode::Enter => {
-                    self.request.method = HttpMethod::from_index(self.method_popup_index);
-                    self.show_method_popup = false;
-                }
-                KeyCode::Esc => {
-                    self.show_method_popup = false;
-                }
-                _ => {}
             }
             return;
         }
@@ -2240,7 +2318,17 @@ impl App {
                 } else if in_request {
                     match self.focus.request_field {
                         RequestField::Method => {
-                            self.method_popup_index = self.request.method.index();
+                            match &self.request.method {
+                                Method::Standard(m) => {
+                                    self.method_popup_index = m.index();
+                                    self.method_custom_input.clear();
+                                }
+                                Method::Custom(s) => {
+                                    self.method_popup_index = HttpMethod::ALL.len();
+                                    self.method_custom_input = s.clone();
+                                }
+                            }
+                            self.method_popup_custom_mode = false;
                             self.show_method_popup = true;
                         }
                         RequestField::Send => {
@@ -2558,12 +2646,12 @@ impl App {
         self.response = ResponseStatus::Loading;
 
         let client = self.client.clone();
-        let method = self.request.method;
+        let method = self.request.method.clone();
         let headers = self.request.headers_text();
         let body = self.request.body_text();
 
         let handle = tokio::spawn(async move {
-            let result = http::send_request(&client, method, &url, &headers, &body).await;
+            let result = http::send_request(&client, &method, &url, &headers, &body).await;
             let _ = tx.send(result).await;
         });
         self.request_handle = Some(handle.abort_handle());

--- a/src/app.rs
+++ b/src/app.rs
@@ -131,15 +131,19 @@ pub enum HttpMethod {
     Put,
     Patch,
     Delete,
+    Head,
+    Options,
 }
 
 impl HttpMethod {
-    pub const ALL: [HttpMethod; 5] = [
+    pub const ALL: [HttpMethod; 7] = [
         HttpMethod::Get,
         HttpMethod::Post,
         HttpMethod::Put,
         HttpMethod::Patch,
         HttpMethod::Delete,
+        HttpMethod::Head,
+        HttpMethod::Options,
     ];
 
     pub fn as_str(&self) -> &'static str {
@@ -149,6 +153,8 @@ impl HttpMethod {
             HttpMethod::Put => "PUT",
             HttpMethod::Patch => "PATCH",
             HttpMethod::Delete => "DELETE",
+            HttpMethod::Head => "HEAD",
+            HttpMethod::Options => "OPTIONS",
         }
     }
 
@@ -159,6 +165,8 @@ impl HttpMethod {
             HttpMethod::Put => 2,
             HttpMethod::Patch => 3,
             HttpMethod::Delete => 4,
+            HttpMethod::Head => 5,
+            HttpMethod::Options => 6,
         }
     }
 
@@ -172,6 +180,8 @@ impl HttpMethod {
             "PUT" => HttpMethod::Put,
             "PATCH" => HttpMethod::Patch,
             "DELETE" => HttpMethod::Delete,
+            "HEAD" => HttpMethod::Head,
+            "OPTIONS" => HttpMethod::Options,
             _ => HttpMethod::Get,
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,6 +19,8 @@ pub async fn send_request(
         HttpMethod::Put => client.put(url),
         HttpMethod::Patch => client.patch(url),
         HttpMethod::Delete => client.delete(url),
+        HttpMethod::Head => client.head(url),
+        HttpMethod::Options => client.request(reqwest::Method::OPTIONS, url),
     };
 
     for line in headers.lines() {
@@ -33,7 +35,11 @@ pub async fn send_request(
         }
     }
 
-    if !body.is_empty() && matches!(method, HttpMethod::Post | HttpMethod::Put | HttpMethod::Patch)
+    if !body.is_empty()
+        && matches!(
+            method,
+            HttpMethod::Post | HttpMethod::Put | HttpMethod::Patch | HttpMethod::Delete
+        )
     {
         builder = builder.body(body.to_string());
     }

--- a/src/storage/io.rs
+++ b/src/storage/io.rs
@@ -56,14 +56,13 @@ pub fn delete_request(id: &str) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::models::HttpMethod;
 
     #[test]
     fn test_save_and_load_request() {
         let request = SavedRequest::new(
             "Test Request".to_string(),
             "https://api.example.com/test".to_string(),
-            HttpMethod::Post,
+            "POST".to_string(),
             "Content-Type: application/json".to_string(),
             r#"{"key": "value"}"#.to_string(),
         );
@@ -77,7 +76,7 @@ mod tests {
         let loaded = load_request(&id).expect("Failed to load request");
         assert_eq!(loaded.name, "Test Request");
         assert_eq!(loaded.url, "https://api.example.com/test");
-        assert_eq!(loaded.method, HttpMethod::Post);
+        assert_eq!(loaded.method, "POST");
 
         // List
         let all = list_requests().expect("Failed to list requests");

--- a/src/storage/migrate.rs
+++ b/src/storage/migrate.rs
@@ -43,6 +43,8 @@ pub fn migrate_legacy(
             HttpMethod::Put => "PUT",
             HttpMethod::Patch => "PATCH",
             HttpMethod::Delete => "DELETE",
+            HttpMethod::Head => "HEAD",
+            HttpMethod::Options => "OPTIONS",
         }
         .to_string();
 

--- a/src/storage/migrate.rs
+++ b/src/storage/migrate.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use crate::storage::models::{HttpMethod, SavedRequest};
+use crate::storage::models::SavedRequest;
 use crate::storage::postman::{PostmanCollection, PostmanItem, PostmanRequest};
 use crate::storage::project::requests_dir;
 
@@ -37,16 +37,7 @@ pub fn migrate_legacy(
     let mut project = PostmanItem::new_folder(project_name);
 
     for request in requests {
-        let method = match request.method {
-            HttpMethod::Get => "GET",
-            HttpMethod::Post => "POST",
-            HttpMethod::Put => "PUT",
-            HttpMethod::Patch => "PATCH",
-            HttpMethod::Delete => "DELETE",
-            HttpMethod::Head => "HEAD",
-            HttpMethod::Options => "OPTIONS",
-        }
-        .to_string();
+        let method = request.method.clone();
 
         let headers = parse_headers(&request.headers);
         let body = if request.body.trim().is_empty() {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -12,7 +12,7 @@ pub use collection::{
     parse_headers, CollectionStore, NodeKind, ProjectInfo, ProjectTree, RequestFile, TreeNode,
 };
 pub use postman::{PostmanHeader, PostmanItem, PostmanRequest};
-pub use models::{HttpMethod, SavedRequest};
+pub use models::SavedRequest;
 pub use project::{
     collection_path, ensure_storage_dir, find_project_root, project_root_key, requests_dir,
     storage_dir, ui_state_path,

--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -1,52 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "UPPERCASE")]
-pub enum HttpMethod {
-    #[default]
-    Get,
-    Post,
-    Put,
-    Patch,
-    Delete,
-    Head,
-    Options,
-}
-
-impl From<crate::app::HttpMethod> for HttpMethod {
-    fn from(method: crate::app::HttpMethod) -> Self {
-        match method {
-            crate::app::HttpMethod::Get => HttpMethod::Get,
-            crate::app::HttpMethod::Post => HttpMethod::Post,
-            crate::app::HttpMethod::Put => HttpMethod::Put,
-            crate::app::HttpMethod::Patch => HttpMethod::Patch,
-            crate::app::HttpMethod::Delete => HttpMethod::Delete,
-            crate::app::HttpMethod::Head => HttpMethod::Head,
-            crate::app::HttpMethod::Options => HttpMethod::Options,
-        }
-    }
-}
-
-impl From<HttpMethod> for crate::app::HttpMethod {
-    fn from(method: HttpMethod) -> Self {
-        match method {
-            HttpMethod::Get => crate::app::HttpMethod::Get,
-            HttpMethod::Post => crate::app::HttpMethod::Post,
-            HttpMethod::Put => crate::app::HttpMethod::Put,
-            HttpMethod::Patch => crate::app::HttpMethod::Patch,
-            HttpMethod::Delete => crate::app::HttpMethod::Delete,
-            HttpMethod::Head => crate::app::HttpMethod::Head,
-            HttpMethod::Options => crate::app::HttpMethod::Options,
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SavedRequest {
     pub id: String,
     pub name: String,
     pub url: String,
-    pub method: HttpMethod,
+    pub method: String,
     pub headers: String,
     pub body: String,
 }
@@ -55,7 +14,7 @@ impl SavedRequest {
     pub fn new(
         name: String,
         url: String,
-        method: HttpMethod,
+        method: String,
         headers: String,
         body: String,
     ) -> Self {
@@ -74,7 +33,7 @@ impl SavedRequest {
         Self::new(
             name,
             request.url_text(),
-            request.method.into(),
+            request.method.as_str().to_string(),
             request.headers_text(),
             request.body_text(),
         )

--- a/src/storage/models.rs
+++ b/src/storage/models.rs
@@ -9,6 +9,8 @@ pub enum HttpMethod {
     Put,
     Patch,
     Delete,
+    Head,
+    Options,
 }
 
 impl From<crate::app::HttpMethod> for HttpMethod {
@@ -19,6 +21,8 @@ impl From<crate::app::HttpMethod> for HttpMethod {
             crate::app::HttpMethod::Put => HttpMethod::Put,
             crate::app::HttpMethod::Patch => HttpMethod::Patch,
             crate::app::HttpMethod::Delete => HttpMethod::Delete,
+            crate::app::HttpMethod::Head => HttpMethod::Head,
+            crate::app::HttpMethod::Options => HttpMethod::Options,
         }
     }
 }
@@ -31,6 +35,8 @@ impl From<HttpMethod> for crate::app::HttpMethod {
             HttpMethod::Put => crate::app::HttpMethod::Put,
             HttpMethod::Patch => crate::app::HttpMethod::Patch,
             HttpMethod::Delete => crate::app::HttpMethod::Delete,
+            HttpMethod::Head => crate::app::HttpMethod::Head,
+            HttpMethod::Options => crate::app::HttpMethod::Options,
         }
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -308,6 +308,8 @@ fn method_color(method: HttpMethod) -> Color {
         HttpMethod::Put => Color::Yellow,
         HttpMethod::Patch => Color::Magenta,
         HttpMethod::Delete => Color::Red,
+        HttpMethod::Head => Color::Cyan,
+        HttpMethod::Options => Color::White,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add HEAD and OPTIONS as first-class HTTP methods with dedicated colors (Cyan/White) and proper request execution
- Add custom method support via "Custom..." popup entry with inline text input, auto-uppercase, and validation
- Fix data loss bug where unknown methods (e.g., PROPFIND, PURGE) were silently mapped to GET on load
- Simplify storage layer by removing redundant `storage::models::HttpMethod` enum

## Changes

### Phase A: HEAD & OPTIONS
- Extended `HttpMethod` enum with `Head` and `Options` variants across `app.rs`, `http.rs`, `ui/mod.rs`, `storage/`
- Added `client.head()` and `client.request(OPTIONS)` execution paths
- Updated body gating: DELETE now sends body; HEAD/OPTIONS do not

### Phase B: Custom Methods
- Created `Method` wrapper enum (`Standard(HttpMethod)` / `Custom(String)`)
- Updated `RequestState.method`, `send_request()`, sidebar, and all rendering to use `Method`
- Custom methods use `reqwest::Method::from_bytes()` and always allow body (WebDAV support)
- Popup UX: "Custom..." entry at bottom, inline text input with auto-uppercase, max 20 chars
- `SavedRequest.method` simplified to `String` — no more lossy enum conversion

## Test plan

- [x] `cargo build` — clean compilation, zero new warnings
- [x] `cargo test` — all 20 tests pass
- [x] `cargo clippy` — no new warnings (13 pre-existing)
- [ ] Manual: open popup → select HEAD → send to any endpoint → verify empty body response
- [ ] Manual: select OPTIONS → verify Allow headers in response
- [ ] Manual: select "Custom..." → type "PURGE" → verify display and execution
- [ ] Manual: type lowercase "purge" → verify auto-uppercased to "PURGE"
- [ ] Manual: save custom method request → reload → verify persistence (no data loss)
- [ ] Manual: load Postman collection with "PROPFIND" → verify loads as Custom, not GET