### PR TITLE
feat: add environment variable system with {{variable}} substitution

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,364 @@
+# Environment Variables
+
+Perseus supports named environments with key-value variable pairs and `{{variable}}` substitution in all request fields. Create environment files as JSON, switch between them with `Ctrl+N`, and see the active environment in the status bar.
+
+## Overview
+
+| Concept | Description |
+|---------|-------------|
+| **Environment** | A named set of key-value pairs (e.g., `dev`, `staging`, `production`) |
+| **Variable** | A key-value pair within an environment (e.g., `base_url` = `http://localhost:3000`) |
+| **Substitution** | `{{variable_name}}` placeholders in request fields are replaced with values at send time |
+| **Quick-switch** | `Ctrl+N` opens a popup to change the active environment from any mode |
+
+Variables are resolved when you press `Ctrl+R` to send a request. The editor always shows raw `{{var}}` templates — substitution only happens in the outgoing request.
+
+## Getting Started
+
+### 1. Create an Environment File
+
+Environment files live in `.perseus/environments/` inside your project root. Each file is a standalone JSON file named after the environment.
+
+Create `.perseus/environments/dev.json`:
+
+```json
+{
+  "name": "dev",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:3000",
+      "enabled": true,
+      "type": "default"
+    },
+    {
+      "key": "api_token",
+      "value": "dev-token-abc123",
+      "enabled": true,
+      "type": "default"
+    }
+  ]
+}
+```
+
+Create `.perseus/environments/staging.json`:
+
+```json
+{
+  "name": "staging",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "https://api.staging.example.com",
+      "enabled": true,
+      "type": "default"
+    },
+    {
+      "key": "api_token",
+      "value": "staging-token-xyz789",
+      "enabled": true,
+      "type": "default"
+    }
+  ]
+}
+```
+
+### 2. Select an Environment
+
+1. Launch Perseus (environments are loaded automatically at startup)
+2. Press `Ctrl+N` to open the environment switcher popup
+3. Use `j`/`k` or arrow keys to highlight an environment
+4. Press `Enter` to activate it
+
+The active environment name appears in the status bar as a blue badge.
+
+### 3. Use Variables in Requests
+
+Type `{{variable_name}}` anywhere in a request field:
+
+- **URL:** `{{base_url}}/api/v1/users`
+- **Headers:** `Authorization: Bearer {{api_token}}`
+- **Body:** `{"server": "{{base_url}}", "key": "{{api_key}}"}`
+- **Auth fields:** Put `{{api_token}}` in a Bearer token field
+
+When you send the request (`Ctrl+R`), Perseus replaces all `{{variables}}` with values from the active environment before sending.
+
+## Environment File Format
+
+Environment files use a Postman-compatible JSON schema. Each file contains a single environment with a name and an array of variables.
+
+### Schema
+
+```json
+{
+  "name": "<environment-name>",
+  "values": [
+    {
+      "key": "<variable-name>",
+      "value": "<variable-value>",
+      "enabled": true,
+      "type": "default"
+    }
+  ]
+}
+```
+
+### Field Reference
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | string | yes | — | Environment name (must match the filename stem) |
+| `values` | array | no | `[]` | List of variable definitions |
+| `values[].key` | string | yes | — | Variable name used in `{{key}}` placeholders |
+| `values[].value` | string | yes | — | Replacement value |
+| `values[].enabled` | boolean | no | `true` | Whether this variable is active for substitution |
+| `values[].type` | string | no | `"default"` | Variable type (for Postman compatibility; use `"default"` or `"secret"`) |
+
+### Naming Rules
+
+Environment names (and therefore filenames) must contain only:
+
+- Alphanumeric characters (`a-z`, `A-Z`, `0-9`)
+- Underscores (`_`)
+- Hyphens (`-`)
+
+Valid: `dev`, `staging`, `production`, `my-local`, `team_shared`
+Invalid: `my env` (space), `dev.local` (dot), `env/test` (slash)
+
+### File Location
+
+```
+{project_root}/
+└── .perseus/
+    ├── collection.json          # Existing — requests and folders
+    ├── config.toml              # Existing — project configuration
+    └── environments/            # Environment files
+        ├── dev.json
+        ├── staging.json
+        └── production.json
+```
+
+Each `.json` file in the `environments/` directory is loaded as a separate environment. The filesystem acts as the index — no registry file is needed.
+
+## Substitution
+
+### How It Works
+
+When you press `Ctrl+R` to send a request, Perseus:
+
+1. Reads the raw text from the URL, headers, body, and auth fields
+2. Looks up the active environment's enabled variables
+3. Scans each field for `{{variable_name}}` patterns
+4. Replaces matched patterns with variable values
+5. Sends the resolved request
+
+The editor always displays the raw template text. Substitution only affects the outgoing HTTP request.
+
+### Substitution Scope
+
+Variables are substituted in all user-editable request fields:
+
+| Field | Example Template | Resolved Value |
+|-------|-----------------|----------------|
+| URL | `{{base_url}}/api/users` | `http://localhost:3000/api/users` |
+| Headers | `X-Api-Key: {{api_key}}` | `X-Api-Key: sk-abc123` |
+| Body | `{"token": "{{auth_token}}"}` | `{"token": "my-secret-token"}` |
+| Bearer Token | `{{api_token}}` | `dev-token-abc123` |
+| Basic Username | `{{username}}` | `admin` |
+| Basic Password | `{{password}}` | `secret` |
+| API Key Name | `{{key_header}}` | `X-Custom-Auth` |
+| API Key Value | `{{key_value}}` | `key-12345` |
+
+Method and response fields are **not** substituted.
+
+### Unresolved Variables
+
+If a `{{variable}}` has no matching key in the active environment (or no environment is selected), it is left as literal text in the sent request. This matches Postman behavior and is non-blocking — the request still sends.
+
+For example, with only `base_url` defined:
+
+```
+Template:  {{base_url}}/api/{{version}}/users
+Sent as:   http://localhost:3000/api/{{version}}/users
+```
+
+This makes it easy to spot missing variables in the response or URL bar.
+
+### Disabled Variables
+
+Variables with `"enabled": false` are excluded from substitution. Use this to temporarily disable a variable without deleting it from the file:
+
+```json
+{
+  "key": "debug_token",
+  "value": "super-secret",
+  "enabled": false,
+  "type": "default"
+}
+```
+
+`{{debug_token}}` will remain as literal text in sent requests until you set `enabled` back to `true`.
+
+### Edge Cases
+
+| Input | Result | Reason |
+|-------|--------|--------|
+| `{{}}` | `{{}}` | Empty variable name — left as literal |
+| `{{name` | `{{name` | Unclosed braces — left as literal |
+| `{{a}}{{b}}` | Both resolved | Adjacent variables are handled correctly |
+| `{{a}}` with no env | `{{a}}` | No environment selected — left as literal |
+| `{{a}}` where `a` resolves to `{{b}}` | Value of `a` (no re-scan) | Single-pass substitution; no nested resolution |
+
+## Environment Switching
+
+### Quick-Switch Popup
+
+Press `Ctrl+N` from any mode (Navigation, Editing, or Sidebar) to open the environment switcher popup.
+
+```
+┌─ Environment ──────────────┐
+│ ✓ No Environment           │
+│   dev                      │
+│   production               │
+│   staging                  │
+└────────────────────────────┘
+```
+
+- A checkmark (`✓`) marks the currently active environment
+- The highlighted item is shown with inverted colors
+- "No Environment" disables all variable substitution
+
+### Popup Controls
+
+| Key | Action |
+|-----|--------|
+| `j` / `Down` | Move selection down |
+| `k` / `Up` | Move selection up |
+| `Enter` | Activate the selected environment |
+| `Esc` / `q` | Close without changing |
+
+The popup closes automatically when you press `Enter` or `Esc`. Only one popup can be open at a time — opening the environment popup closes any other open popup (method, auth type).
+
+### Status Bar Indicator
+
+When an environment is active, its name appears as a blue badge in the status bar:
+
+```
+ NAVIGATION  Request > URL  │  hjkl:nav ...  │   dev
+```
+
+When no environment is selected, the indicator is hidden.
+
+## Practical Examples
+
+### Multi-Environment API Development
+
+Create three environments for a typical development workflow:
+
+**`.perseus/environments/local.json`**
+```json
+{
+  "name": "local",
+  "values": [
+    { "key": "base_url", "value": "http://localhost:3000", "enabled": true, "type": "default" },
+    { "key": "api_key", "value": "dev-key-local", "enabled": true, "type": "default" }
+  ]
+}
+```
+
+**`.perseus/environments/staging.json`**
+```json
+{
+  "name": "staging",
+  "values": [
+    { "key": "base_url", "value": "https://api.staging.example.com", "enabled": true, "type": "default" },
+    { "key": "api_key", "value": "staging-key-abc123", "enabled": true, "type": "default" }
+  ]
+}
+```
+
+**`.perseus/environments/production.json`**
+```json
+{
+  "name": "production",
+  "values": [
+    { "key": "base_url", "value": "https://api.example.com", "enabled": true, "type": "default" },
+    { "key": "api_key", "value": "prod-key-xyz789", "enabled": true, "type": "default" }
+  ]
+}
+```
+
+Set your URL to `{{base_url}}/api/v1/users` and headers to `X-Api-Key: {{api_key}}`. Switch between environments with `Ctrl+N` — each request hits the right server with the right credentials.
+
+### Auth Token Rotation
+
+Store auth tokens in environment variables to update them in one place:
+
+```json
+{
+  "name": "dev",
+  "values": [
+    { "key": "base_url", "value": "http://localhost:3000", "enabled": true, "type": "default" },
+    { "key": "access_token", "value": "eyJhbGciOiJIUzI1NiIs...", "enabled": true, "type": "default" }
+  ]
+}
+```
+
+In the Auth tab, select Bearer Token and set the token field to `{{access_token}}`. When the token expires, update the value in `dev.json` and restart Perseus — all requests using `{{access_token}}` pick up the new value.
+
+### Shared Team Environments
+
+Environment files are plain JSON in the `.perseus/` directory and can be committed to version control:
+
+```
+# .gitignore
+.perseus/environments/local.json    # Personal env — don't commit
+```
+
+```
+# Committed to git
+.perseus/environments/dev.json       # Team dev environment
+.perseus/environments/staging.json   # Shared staging config
+```
+
+Team members get the shared environments automatically when they pull the repository. Personal environments stay local.
+
+## Postman Compatibility
+
+The environment file format is compatible with Postman's environment schema. This means:
+
+- Postman environment exports can be placed directly in `.perseus/environments/` and used by Perseus
+- Perseus environment files can be imported into Postman as environments
+- The `key`, `value`, `enabled`, and `type` fields are preserved in both directions
+
+To use a Postman environment export:
+
+1. Export the environment from Postman (Settings > Environments > Export)
+2. Copy the exported `.json` file into `.perseus/environments/`
+3. Ensure the `"name"` field matches the filename (e.g., `dev.json` contains `"name": "dev"`)
+4. Restart Perseus
+
+## Keyboard Reference
+
+| Context | Key | Action |
+|---------|-----|--------|
+| Any mode | `Ctrl+N` | Toggle environment switcher popup |
+| Env popup | `j` / `Down` | Move selection down |
+| Env popup | `k` / `Up` | Move selection up |
+| Env popup | `Enter` | Activate selected environment |
+| Env popup | `Esc` / `q` | Close popup without changing |
+| Any mode | `Ctrl+R` | Send request (variables are substituted) |
+
+## Limitations
+
+These limitations are intentional for v1 and may be addressed in future versions:
+
+| Limitation | Current Behavior | Workaround |
+|------------|-----------------|------------|
+| No in-app environment editing | Edit JSON files directly | Terminal users can edit `.perseus/environments/*.json` in any text editor |
+| No global variables | Each environment is independent | Create a "shared" or "globals" environment with common values |
+| No session persistence of active env | Active environment resets to "None" on restart | Press `Ctrl+N` once after launching |
+| No nested substitution | `{{a}}` values are not re-scanned for `{{b}}` patterns | Flatten variable references |
+| No dynamic variables | No `{{$timestamp}}` or `{{$randomUUID}}` support | Compute values externally and paste them into the environment file |
+| No variable autocomplete | Typing `{{` does not show suggestions | Reference the environment file for variable names |
+| String values only | All variable values are treated as strings | Consistent with Postman; sufficient for URL/header/body text |

--- a/src/app.rs
+++ b/src/app.rs
@@ -2405,6 +2405,35 @@ impl App {
             return;
         }
 
+        // Handle environment popup when open
+        if self.show_env_popup {
+            match key.code {
+                KeyCode::Char('j') | KeyCode::Down => {
+                    let count = self.environments.len() + 1; // +1 for "No Environment"
+                    self.env_popup_index = (self.env_popup_index + 1) % count;
+                }
+                KeyCode::Char('k') | KeyCode::Up => {
+                    let count = self.environments.len() + 1;
+                    self.env_popup_index =
+                        (self.env_popup_index + count - 1) % count;
+                }
+                KeyCode::Enter => {
+                    self.active_environment_name = if self.env_popup_index == 0 {
+                        None
+                    } else {
+                        Some(self.environments[self.env_popup_index - 1].name.clone())
+                    };
+                    self.show_env_popup = false;
+                }
+                KeyCode::Esc | KeyCode::Char('q') => {
+                    self.show_env_popup = false;
+                }
+                _ => {}
+            }
+            self.dirty = true;
+            return;
+        }
+
         // Handle auth type popup when open
         if self.show_auth_type_popup {
             self.handle_auth_type_popup(key);
@@ -2558,6 +2587,23 @@ impl App {
             return;
         }
 
+        // Ctrl+N: environment quick-switch popup
+        if key.code == KeyCode::Char('n') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.show_method_popup = false;
+            self.show_auth_type_popup = false;
+            self.show_env_popup = !self.show_env_popup;
+            if self.show_env_popup {
+                self.env_popup_index = self
+                    .active_environment_name
+                    .as_ref()
+                    .and_then(|name| self.environments.iter().position(|e| e.name == *name))
+                    .map(|i| i + 1)
+                    .unwrap_or(0);
+            }
+            self.dirty = true;
+            return;
+        }
+
         // Ctrl+h/l: horizontal navigation in input row
         if in_request && key.modifiers.contains(KeyModifiers::CONTROL) {
             match key.code {
@@ -2695,6 +2741,23 @@ impl App {
             return;
         }
 
+        // Ctrl+N: environment quick-switch popup from sidebar mode
+        if key.code == KeyCode::Char('n') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.show_method_popup = false;
+            self.show_auth_type_popup = false;
+            self.show_env_popup = !self.show_env_popup;
+            if self.show_env_popup {
+                self.env_popup_index = self
+                    .active_environment_name
+                    .as_ref()
+                    .and_then(|name| self.environments.iter().position(|e| e.name == *name))
+                    .map(|i| i + 1)
+                    .unwrap_or(0);
+            }
+            self.dirty = true;
+            return;
+        }
+
         if key.code == KeyCode::Esc {
             if self.sidebar.popup.is_some() {
                 self.sidebar.popup = None;
@@ -2738,6 +2801,23 @@ impl App {
             } else {
                 self.send_request(tx);
             }
+            return;
+        }
+
+        // Ctrl+N: environment quick-switch popup, even in editing mode
+        if key.code == KeyCode::Char('n') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.show_method_popup = false;
+            self.show_auth_type_popup = false;
+            self.show_env_popup = !self.show_env_popup;
+            if self.show_env_popup {
+                self.env_popup_index = self
+                    .active_environment_name
+                    .as_ref()
+                    .and_then(|name| self.environments.iter().position(|e| e.name == *name))
+                    .map(|i| i + 1)
+                    .unwrap_or(0);
+            }
+            self.dirty = true;
             return;
         }
 
@@ -2952,8 +3032,8 @@ impl App {
     }
 
     fn send_request(&mut self, tx: mpsc::Sender<Result<ResponseData, String>>) {
-        let url = self.request.url_text();
-        if url.is_empty() {
+        let raw_url = self.request.url_text();
+        if raw_url.is_empty() {
             self.response = ResponseStatus::Error("URL is required".to_string());
             return;
         }
@@ -2962,13 +3042,20 @@ impl App {
             return;
         }
 
+        // Resolve variables from active environment
+        let variables = environment::resolve_variables(self.active_environment());
+
+        let (url, _) = environment::substitute(&raw_url, &variables);
+        let (headers, _) =
+            environment::substitute(&self.request.headers_text(), &variables);
+        let (body, _) =
+            environment::substitute(&self.request.body_text(), &variables);
+        let auth = self.build_resolved_auth_config(&variables);
+
         self.response = ResponseStatus::Loading;
 
         let client = self.client.clone();
         let method = self.request.method.clone();
-        let headers = self.request.headers_text();
-        let body = self.request.body_text();
-        let auth = self.request.build_auth_config();
 
         let handle = tokio::spawn(async move {
             let result =
@@ -2976,6 +3063,38 @@ impl App {
             let _ = tx.send(result).await;
         });
         self.request_handle = Some(handle.abort_handle());
+    }
+
+    fn build_resolved_auth_config(
+        &self,
+        variables: &std::collections::HashMap<String, String>,
+    ) -> http::AuthConfig {
+        match self.request.auth_type {
+            AuthType::NoAuth => http::AuthConfig::NoAuth,
+            AuthType::Bearer => {
+                let (token, _) =
+                    environment::substitute(&self.request.auth_token_text(), variables);
+                http::AuthConfig::Bearer { token }
+            }
+            AuthType::Basic => {
+                let (username, _) =
+                    environment::substitute(&self.request.auth_username_text(), variables);
+                let (password, _) =
+                    environment::substitute(&self.request.auth_password_text(), variables);
+                http::AuthConfig::Basic { username, password }
+            }
+            AuthType::ApiKey => {
+                let (key, _) =
+                    environment::substitute(&self.request.auth_key_name_text(), variables);
+                let (value, _) =
+                    environment::substitute(&self.request.auth_key_value_text(), variables);
+                http::AuthConfig::ApiKey {
+                    key,
+                    value,
+                    location: self.request.api_key_location,
+                }
+            }
+        }
     }
 
     fn cancel_request(&mut self) {

--- a/src/storage/environment.rs
+++ b/src/storage/environment.rs
@@ -1,0 +1,330 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::project;
+
+// --- Data model (Postman-compatible) ---
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvironmentVariable {
+    pub key: String,
+    pub value: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(rename = "type", default = "default_type")]
+    pub var_type: String,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_type() -> String {
+    "default".to_string()
+}
+
+impl EnvironmentVariable {
+    pub fn new(key: &str, value: &str) -> Self {
+        Self {
+            key: key.to_string(),
+            value: value.to_string(),
+            enabled: true,
+            var_type: "default".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Environment {
+    pub name: String,
+    #[serde(default)]
+    pub values: Vec<EnvironmentVariable>,
+}
+
+// --- File I/O ---
+
+pub fn load_environment(path: &Path) -> Result<Environment, String> {
+    let contents =
+        fs::read_to_string(path).map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+    serde_json::from_str(&contents)
+        .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))
+}
+
+pub fn save_environment(env: &Environment) -> Result<(), String> {
+    if !is_safe_env_name(&env.name) {
+        return Err(format!(
+            "Invalid environment name '{}': must be non-empty and contain only alphanumeric, underscore, or hyphen characters",
+            env.name
+        ));
+    }
+    let dir = project::ensure_environments_dir()?;
+    let path = dir.join(format!("{}.json", env.name));
+    let json = serde_json::to_string_pretty(env)
+        .map_err(|e| format!("Failed to serialize environment: {}", e))?;
+    fs::write(&path, json).map_err(|e| format!("Failed to write {}: {}", path.display(), e))
+}
+
+pub fn load_all_environments() -> Result<Vec<Environment>, String> {
+    let dir = match project::environments_dir() {
+        Some(d) => d,
+        None => return Ok(Vec::new()),
+    };
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut environments = Vec::new();
+    let entries =
+        fs::read_dir(&dir).map_err(|e| format!("Failed to read environments dir: {}", e))?;
+
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("Failed to read dir entry: {}", e))?;
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) == Some("json") {
+            match load_environment(&path) {
+                Ok(env) => environments.push(env),
+                Err(err) => eprintln!("Warning: skipping environment file: {}", err),
+            }
+        }
+    }
+
+    environments.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(environments)
+}
+
+pub fn delete_environment_file(name: &str) -> Result<(), String> {
+    let dir = project::environments_dir()
+        .ok_or("Could not find environments directory")?;
+    let path = dir.join(format!("{}.json", name));
+    if path.exists() {
+        fs::remove_file(&path)
+            .map_err(|e| format!("Failed to delete {}: {}", path.display(), e))?;
+    }
+    Ok(())
+}
+
+fn is_safe_env_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+}
+
+// --- Substitution engine ---
+
+/// Replace `{{variable}}` patterns with values from the given map.
+/// Returns `(resolved_text, unresolved_variable_names)`.
+pub fn substitute(template: &str, variables: &HashMap<String, String>) -> (String, Vec<String>) {
+    let mut result = String::with_capacity(template.len());
+    let mut unresolved = Vec::new();
+    let mut chars = template.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '{' && chars.peek() == Some(&'{') {
+            chars.next(); // consume second '{'
+            let mut name = String::new();
+            let mut closed = false;
+            while let Some(nc) = chars.next() {
+                if nc == '}' && chars.peek() == Some(&'}') {
+                    chars.next(); // consume second '}'
+                    closed = true;
+                    break;
+                }
+                name.push(nc);
+            }
+            if closed && !name.is_empty() {
+                if let Some(val) = variables.get(&name) {
+                    result.push_str(val);
+                } else {
+                    result.push_str("{{");
+                    result.push_str(&name);
+                    result.push_str("}}");
+                    unresolved.push(name);
+                }
+            } else {
+                // Unclosed braces or empty name — leave as literal
+                result.push_str("{{");
+                result.push_str(&name);
+                if closed {
+                    // empty name case: {{}}
+                    result.push_str("}}");
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+    (result, unresolved)
+}
+
+/// Collect enabled variables from an environment into a lookup map.
+pub fn resolve_variables(env: Option<&Environment>) -> HashMap<String, String> {
+    let mut vars = HashMap::new();
+    if let Some(env) = env {
+        for var in &env.values {
+            if var.enabled {
+                vars.insert(var.key.clone(), var.value.clone());
+            }
+        }
+    }
+    vars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- Serialization tests ---
+
+    #[test]
+    fn test_environment_serialize_postman_compatible() {
+        let env = Environment {
+            name: "dev".to_string(),
+            values: vec![
+                EnvironmentVariable::new("base_url", "http://localhost:3000"),
+                EnvironmentVariable {
+                    key: "disabled_var".to_string(),
+                    value: "unused".to_string(),
+                    enabled: false,
+                    var_type: "secret".to_string(),
+                },
+            ],
+        };
+
+        let json = serde_json::to_string_pretty(&env).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["name"], "dev");
+        assert_eq!(parsed["values"][0]["key"], "base_url");
+        assert_eq!(parsed["values"][0]["value"], "http://localhost:3000");
+        assert_eq!(parsed["values"][0]["enabled"], true);
+        assert_eq!(parsed["values"][0]["type"], "default");
+        assert_eq!(parsed["values"][1]["enabled"], false);
+        assert_eq!(parsed["values"][1]["type"], "secret");
+    }
+
+    #[test]
+    fn test_environment_deserialize_with_defaults() {
+        let json = r#"{"name":"test","values":[{"key":"k","value":"v"}]}"#;
+        let env: Environment = serde_json::from_str(json).unwrap();
+        assert_eq!(env.values[0].enabled, true);
+        assert_eq!(env.values[0].var_type, "default");
+    }
+
+    #[test]
+    fn test_environment_deserialize_empty_values() {
+        let json = r#"{"name":"empty"}"#;
+        let env: Environment = serde_json::from_str(json).unwrap();
+        assert!(env.values.is_empty());
+    }
+
+    // --- Substitution tests ---
+
+    #[test]
+    fn test_substitute_basic() {
+        let mut vars = HashMap::new();
+        vars.insert("host".to_string(), "localhost:3000".to_string());
+        let (result, unresolved) = substitute("{{host}}/api", &vars);
+        assert_eq!(result, "localhost:3000/api");
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn test_substitute_multiple_variables() {
+        let mut vars = HashMap::new();
+        vars.insert("scheme".to_string(), "https".to_string());
+        vars.insert("host".to_string(), "example.com".to_string());
+        vars.insert("port".to_string(), "8080".to_string());
+        let (result, unresolved) = substitute("{{scheme}}://{{host}}:{{port}}", &vars);
+        assert_eq!(result, "https://example.com:8080");
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn test_substitute_unresolved() {
+        let vars = HashMap::new();
+        let (result, unresolved) = substitute("{{missing}}", &vars);
+        assert_eq!(result, "{{missing}}");
+        assert_eq!(unresolved, vec!["missing"]);
+    }
+
+    #[test]
+    fn test_substitute_empty_template() {
+        let vars = HashMap::new();
+        let (result, unresolved) = substitute("", &vars);
+        assert_eq!(result, "");
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn test_substitute_no_variables_in_template() {
+        let mut vars = HashMap::new();
+        vars.insert("unused".to_string(), "val".to_string());
+        let (result, unresolved) = substitute("https://example.com", &vars);
+        assert_eq!(result, "https://example.com");
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn test_substitute_adjacent_variables() {
+        let mut vars = HashMap::new();
+        vars.insert("a".to_string(), "hello".to_string());
+        vars.insert("b".to_string(), "world".to_string());
+        let (result, unresolved) = substitute("{{a}}{{b}}", &vars);
+        assert_eq!(result, "helloworld");
+        assert!(unresolved.is_empty());
+    }
+
+    #[test]
+    fn test_substitute_unclosed_braces() {
+        let vars = HashMap::new();
+        let (result, _) = substitute("{{name", &vars);
+        assert_eq!(result, "{{name");
+    }
+
+    #[test]
+    fn test_substitute_empty_name() {
+        let vars = HashMap::new();
+        let (result, _) = substitute("{{}}", &vars);
+        assert_eq!(result, "{{}}");
+    }
+
+    #[test]
+    fn test_resolve_variables_enabled_only() {
+        let env = Environment {
+            name: "test".to_string(),
+            values: vec![
+                EnvironmentVariable::new("enabled_var", "yes"),
+                EnvironmentVariable {
+                    key: "disabled_var".to_string(),
+                    value: "no".to_string(),
+                    enabled: false,
+                    var_type: "default".to_string(),
+                },
+            ],
+        };
+        let vars = resolve_variables(Some(&env));
+        assert_eq!(vars.get("enabled_var"), Some(&"yes".to_string()));
+        assert_eq!(vars.get("disabled_var"), None);
+    }
+
+    #[test]
+    fn test_resolve_variables_none() {
+        let vars = resolve_variables(None);
+        assert!(vars.is_empty());
+    }
+
+    #[test]
+    fn test_safe_env_name() {
+        assert!(is_safe_env_name("dev"));
+        assert!(is_safe_env_name("my-env"));
+        assert!(is_safe_env_name("env_123"));
+        assert!(!is_safe_env_name(""));
+        assert!(!is_safe_env_name("bad name"));
+        assert!(!is_safe_env_name("bad/name"));
+        assert!(!is_safe_env_name("bad.name"));
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,6 +1,7 @@
 #![allow(unused)]
 
 mod collection;
+pub mod environment;
 mod migrate;
 mod models;
 mod postman;
@@ -11,11 +12,15 @@ mod ui_state;
 pub use collection::{
     parse_headers, CollectionStore, NodeKind, ProjectInfo, ProjectTree, RequestFile, TreeNode,
 };
+pub use environment::{
+    delete_environment_file, load_all_environments, save_environment, Environment,
+    EnvironmentVariable,
+};
 pub use postman::{PostmanAuth, PostmanHeader, PostmanItem, PostmanRequest};
 pub use models::SavedRequest;
 pub use project::{
-    collection_path, ensure_storage_dir, find_project_root, project_root_key, requests_dir,
-    storage_dir, ui_state_path,
+    collection_path, ensure_environments_dir, ensure_storage_dir, environments_dir,
+    find_project_root, project_root_key, requests_dir, storage_dir, ui_state_path,
 };
 pub use session_state::{
     load_session_for_root, load_sessions, save_session_for_root, save_sessions, SessionState,

--- a/src/storage/project.rs
+++ b/src/storage/project.rs
@@ -52,3 +52,16 @@ pub fn requests_dir() -> Option<PathBuf> {
 pub fn ui_state_path() -> Option<PathBuf> {
     storage_dir().map(|root| root.join("ui.json"))
 }
+
+pub fn environments_dir() -> Option<PathBuf> {
+    storage_dir().map(|root| root.join("environments"))
+}
+
+pub fn ensure_environments_dir() -> Result<PathBuf, String> {
+    let dir = environments_dir().ok_or(
+        "Could not find project root. Run from a directory with .git, Cargo.toml, package.json, or create a .perseus folder.",
+    )?;
+    fs::create_dir_all(&dir)
+        .map_err(|e| format!("Failed to create environments directory: {}", e))?;
+    Ok(dir)
+}


### PR DESCRIPTION
## Summary

- Add named environments (dev, staging, production, custom) stored as individual JSON files in `.perseus/environments/`
- Implement `{{variable}}` substitution engine that resolves placeholders in URL, headers, body, and auth fields at send time
- Add `Ctrl+N` quick-switch popup accessible from any mode (Navigation, Editing, Sidebar) with j/k navigation
- Display active environment name as a blue badge in the status bar
- Postman-compatible environment file format for future import/export

## Changes

| File | What |
|------|------|
| `src/storage/environment.rs` | **New** — `Environment`/`EnvironmentVariable` data models, file I/O, `substitute()` engine, `resolve_variables()`, 14 unit tests |
| `src/storage/project.rs` | Add `environments_dir()` and `ensure_environments_dir()` helpers |
| `src/storage/mod.rs` | Re-export environment module and project helpers |
| `src/app.rs` | Add env state to `App`, load at startup, `Ctrl+N` handler in all 3 modes, popup key handling, `build_resolved_auth_config()`, wire substitution into `send_request()` |
| `src/ui/mod.rs` | Centered environment popup overlay, status bar env indicator, help overlay and hints updated |
| `docs/environment-variables.md` | **New** — Full feature documentation |

## Design Decisions

- **Individual JSON files per environment** — filesystem is the index, git-friendly, easy to share
- **State-machine scanner** (no regex dependency) for `{{variable}}` substitution
- **Substitution at send time only** — editor always shows raw templates
- **Unresolved variables left as literal text** — matches Postman behavior, non-blocking
- **Postman-compatible schema** — enables future environment import

## Test Plan

- [x] 14 unit tests for substitution engine (basic, multiple vars, unresolved, empty, adjacent, edge cases)
- [x] Serialization roundtrip tests (Postman-compatible format, defaults, empty values)
- [x] Environment name validation tests (safe filenames)
- [x] `cargo check` passes at each phase
- [x] `cargo test` — all 34 tests pass
- [ ] Manual: create env files, Ctrl+N to switch, verify substitution in sent requests
- [ ] Manual: verify status bar indicator appears/disappears
- [ ] Manual: verify auth field substitution (Bearer, Basic, API Key)